### PR TITLE
[Feat] 장바구니 일반 상품 클릭 시 페이지 이동

### DIFF
--- a/src/app/custom-keyboard/_components/navigator/CartModal.tsx
+++ b/src/app/custom-keyboard/_components/navigator/CartModal.tsx
@@ -165,6 +165,7 @@ export default function CartModal({
           toast.error('장바구니 담기에 실패했습니다');
         },
         onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ['cartData'] });
           toast.success('장바구니에 담았습니다', {
             onClose: () => {
               router.push(ROUTER.MY_PAGE.CART);

--- a/src/app/my-info/(account)/cart/_components/CartCard.tsx
+++ b/src/app/my-info/(account)/cart/_components/CartCard.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
+import Link from 'next/link';
 
 import { putChangeCartData } from '@/api/cartAPI';
 import { postCreateOrder } from '@/api/orderAPI';
@@ -32,6 +33,7 @@ interface ShopCardProps {
 const CATEGORY = {
   keyboard: '키보드',
   keycap: '키캡',
+  switch: '스위치',
   etc: '기타 용품',
 };
 
@@ -115,18 +117,24 @@ export default function CartCard({ cardData, type }: CustomCardProps | ShopCardP
         <div>
           <CardCheckBox id={cardData.id} type={type} />
         </div>
-        <div className={cn('product-wrapper')}>
-          <Image src={imageURL} width={104} height={104} alt='이미지' className={cn('image')} priority />
-          <div className={cn('information-wrapper')}>
-            {type === 'shop' && <div className={cn('type')}>{category}</div>}
-            <div className={cn('title')}> {title}</div>
-            {type === 'custom' ? (
-              <CustomOption customData={cardData} />
-            ) : (
+        {type === 'shop' ? (
+          <Link className={cn('product-wrapper')} href={`/shop/${cardData.category}/${cardData.prductId}`}>
+            <Image src={imageURL} width={104} height={104} alt='이미지' className={cn('image')} priority />
+            <div className={cn('information-wrapper')}>
+              {type === 'shop' && <div className={cn('type')}>{category}</div>}
+              <div className={cn('title')}> {title}</div>
               <ShopOption optionName={cardData.optionName} count={cardData.count} />
-            )}
+            </div>
+          </Link>
+        ) : (
+          <div className={cn('product-wrapper')}>
+            <Image src={imageURL} width={104} height={104} alt='이미지' className={cn('image')} priority />
+            <div className={cn('information-wrapper')}>
+              <div className={cn('title')}> {title}</div>
+              <CustomOption customData={cardData} />
+            </div>
           </div>
-        </div>
+        )}
       </div>
       <div className={cn('price')}>{price.toLocaleString()}원</div>
       <div className={cn('button-wrapper')}>

--- a/src/app/shop/[category]/[productId]/_components/Product/OptionWithButtons.tsx
+++ b/src/app/shop/[category]/[productId]/_components/Product/OptionWithButtons.tsx
@@ -7,7 +7,7 @@ import SignInModal from '@/components/SignInModal/SignInModal';
 import { ROUTER } from '@/constants/route';
 import type { CartProductType, ProductType } from '@/types/ProductTypes';
 import { Users } from '@/types/userType';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useQueryClient, useMutation, useQuery } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -29,6 +29,7 @@ interface SelectedOptionType {
 const OPTION_PLACEHOLDER = '스위치 (필수)';
 
 export default function OptionWithButton({ productData }: OptionWithButtonProps) {
+  const queryClient = useQueryClient();
   const { id: productId, optionList, price } = productData;
 
   const optionNames = optionList?.map((option) => option.optionName);
@@ -93,6 +94,7 @@ export default function OptionWithButton({ productData }: OptionWithButtonProps)
   const handleAddCartProduct = (data: CartProductType) => {
     addCartProduct(data, {
       onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['cartData'] });
         toast.success('상품이 장바구니에 담겼습니다.');
         setSelectedOptions([]);
       },

--- a/src/components/SignInModal/SignInModal.tsx
+++ b/src/components/SignInModal/SignInModal.tsx
@@ -54,10 +54,8 @@ export default function SignInModal({ isOpen, onClose }: SigninModalProps) {
       if (responseData.status === 'SUCCESS') {
         setCookie('accessToken', responseData.data.accessToken);
         setCookie('refreshToken', responseData.data.refreshToken);
+        onClose();
         toast.success('로그인이 성공적으로 완료되었습니다.', {
-          onClose: () => {
-            onClose();
-          },
           autoClose: 2000,
         });
       } else if (responseData.status === 'FAIL') {

--- a/src/styles/globals/_fonts.scss
+++ b/src/styles/globals/_fonts.scss
@@ -1,4 +1,11 @@
 @font-face {
+  font-family: Pretendard-Thin;
+  font-style: normal;
+  font-weight: 100;
+  src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Thin.woff') format('woff');
+}
+
+@font-face {
   font-family: Pretendard-Regular;
   font-style: normal;
   font-weight: 400;
@@ -43,7 +50,9 @@
 @mixin font-mixin($font-family, $font-size, $font-weight) {
   $line-height: line-height-calc($font-family, $font-size);
   @if $font-family == 'Pretendard' {
-    @if $font-weight == 400 {
+    @if $font-weight == 100 {
+      font-family: Pretendard-Thin, sans-serif;
+    } @else if $font-weight == 400 {
       font-family: Pretendard-Regular, sans-serif;
     } @else if $font-weight == 500 {
       font-family: Pretendard-Medium, sans-serif;


### PR DESCRIPTION
## 🚀 작업 내용

- 장바구니 일반 상품 클릭 시 상품 상세 페이지 이동

## 📝 참고 사항

- 장바구니 페이지 장바구니 담기 시 장바구니 쿼리 다시 fetch 되도록 추가
- pretendard 100 weight 추가
- 로그인 모달 toast 애니메이션 관계 없이 바로 닫히도록 수정

## 🖼️ 스크린샷

![image](이미지url)

## 🚨 관련 이슈 (이슈 번호)
- close #129 

## ✅ 체크리스트

- [x] Code Review 요청
- [x] Label 설정
- [x] PR 제목 규칙에 맞는지 확인
